### PR TITLE
This PR corrects mis-spells, linting issues and a few other issues

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -26,9 +26,5 @@ func init() {
 	// Debug-Environment detection
 	debugEnv := os.Getenv("CITF_VERBOSE_LOG")
 
-	if strings.ToLower(debugEnv) == "true" {
-		DebugEnabled = true
-	} else {
-		DebugEnabled = false
-	}
+	DebugEnabled = strings.ToLower(debugEnv) == "true"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -57,22 +57,26 @@ func LoadConf(confFilePath string) error {
 	return nil
 }
 
+// getConfValueByStringField returns value of the given field string in given Configuration
 func getConfValueByStringField(conf Configuration, field string) string {
 	r := reflect.ValueOf(conf)
 	f := reflect.Indirect(r).FieldByName(field)
 	return f.String()
 }
 
+// GetDefaultValueByStringField returns the value of the given field string in Default Configuration
 // fields should be in exact case as the field is present in struct Configuration
 func GetDefaultValueByStringField(field string) string {
 	return getConfValueByStringField(defaultConf, field)
 }
 
+// GetUserConfValueByStringField returns the value of the given field string in Default Configuration
 // fields should be in exact case as the field is present in struct Configuration
 func GetUserConfValueByStringField(field string) string {
 	return getConfValueByStringField(Conf, field)
 }
 
+// GetConf returns the applicable configuration for the given field
 func GetConf(field string) string {
 	if value, ok := os.LookupEnv("CITF_CONF_" + strings.ToUpper(field)); ok {
 		return value
@@ -83,6 +87,7 @@ func GetConf(field string) string {
 	return GetDefaultValueByStringField(field)
 }
 
+// Environment returns the environment which should be used in testing
 func Environment() string {
 	return GetConf("Environment")
 }

--- a/environments/docker/general.go
+++ b/environments/docker/general.go
@@ -42,6 +42,7 @@ func init() {
 }
 
 // Docker is a struct which will be the driver for all the methods related to docker
+// Docker implements github.com/openebs/CITF/Enviromnent interface
 type Docker struct{}
 
 // NewDocker returns Docker struct

--- a/environments/docker/teardown.go
+++ b/environments/docker/teardown.go
@@ -32,7 +32,7 @@ func (docker Docker) Teardown() error {
 		for _, container := range containers {
 			err = runCommand("docker stop -f " + container)
 			if err != nil {
-				glog.Errorf("error occured while stopping docker container: %s. Error: %+v\n", container, err)
+				glog.Errorf("error occurred while stopping docker container: %s. Error: %+v\n", container, err)
 			} else {
 				fmt.Printf("Stopped container: %s\n", container)
 			}

--- a/environments/minikube/general.go
+++ b/environments/minikube/general.go
@@ -43,6 +43,7 @@ func init() {
 }
 
 // Minikube is a struct which will be the driver for all the methods related to minikube
+// Minikube implements github.com/openebs/CITF/Enviromnent interface
 type Minikube struct {
 	// Timeout is the timeout that will be used throughout the minikube package
 	// for timeout in any operation if requires.

--- a/environments/minikube/setup.go
+++ b/environments/minikube/setup.go
@@ -84,7 +84,7 @@ func (minikube Minikube) Setup() error {
 
 	if common.DebugEnabled {
 		if err != nil {
-			fmt.Printf("Error occured while checking minikube status. Error: %+v\n", err)
+			fmt.Printf("Error occurred while checking minikube status. Error: %+v\n", err)
 		} else {
 			fmt.Printf("minikube status: %q\n", minikubeStatus)
 		}

--- a/utils/k8s/k8s.go
+++ b/utils/k8s/k8s.go
@@ -72,7 +72,7 @@ func (k8s K8S) GetPod(namespace, podNamePrefix string) (core_v1.Pod, error) {
 		// List pods
 		pods, err := k8s.Clientset.CoreV1().Pods(namespace).List(meta_v1.ListOptions{})
 		if err != nil {
-			fmt.Printf("Error occured: %+v\n", err)
+			fmt.Printf("Error occurred: %+v\n", err)
 		}
 
 		// Find the Pod
@@ -197,7 +197,7 @@ func (k8s K8S) GetNodeNames() (nodeNames []string, err error) {
 //    :param string node_name: Name of the node.
 //    :param string key: Key of the label.
 //    :param string value: Value of the label.
-//    :return: error: if any error occured or nil otherwise.
+//    :return: error: if any error occurred or nil otherwise.
 // func LabelNode(nodeName, key, value string) error { return fmt.Errorf("Not Implemented") }
 
 // GetDaemonset returns the k8s.io/api/extensions/v1beta1.DaemonSet for the name supplied.
@@ -235,7 +235,7 @@ func (k8s K8S) GetDaemonsetStructFromYamlBytes(yamlBytes []byte) (v1beta1.Daemon
 
 	err = json.Unmarshal(jsonBytes, &ds)
 	if err != nil {
-		return ds, fmt.Errorf("error occured while marshaling into Daemonset struct. Error: %+v", err)
+		return ds, fmt.Errorf("error occurred while marshaling into Daemonset struct. Error: %+v", err)
 	}
 
 	return ds, nil
@@ -266,7 +266,7 @@ func (k8s K8S) YAMLApply(yamlPath string) error {
 // :param io.Reader stdin: Standerd Input if necessary, otherwise `nil`
 // :return: string: Output of the command. (STDOUT)
 //          string: Errors. (STDERR)
-//           error: If any error has occured otherwise `nil`
+//           error: If any error has occurred otherwise `nil`
 // TODO: Need to fix the error (in exec.Steam) (unable to upgrade connection: you must specify at least 1 of stdin, stdout, stderr)
 func (k8s K8S) ExecToPodThroughAPI(command, podName, namespace string, stdin io.Reader) (string, string, error) {
 	req := k8s.Clientset.Core().RESTClient().Post().
@@ -308,7 +308,7 @@ func (k8s K8S) ExecToPodThroughAPI(command, podName, namespace string, stdin io.
 // :param string pod_name: Pod name
 // :param string namespace: namespace of the Pod.
 // :return: string: Output of the command. (STDOUT)
-//           error: If any error has occured otherwise `nil`
+//           error: If any error has occurred otherwise `nil`
 func (k8s K8S) ExecToPod(command, podName, namespace string) (string, error) {
 	stdout, stderr, err := k8s.ExecToPodThroughAPI(command, podName, namespace, nil)
 	if err == nil {
@@ -324,7 +324,7 @@ func (k8s K8S) ExecToPod(command, podName, namespace string) (string, error) {
 // :param string pod_name: Name of the pod. (required)
 // :param string namespace: Namespace of the pod. (required)
 // :return: string: Log of the pod specified.
-//           error: If an error has occured, otherwise `nil`
+//           error: If an error has occurred, otherwise `nil`
 // TODO: Fix in API call (Error: GroupVersion is required when initializing a RESTClient)
 func (k8s K8S) GetLog(podName, namespace string) (string, error) {
 	// We can't declare a variable somewhere which can be skipped by goto

--- a/utils/string/string.go
+++ b/utils/string/string.go
@@ -29,19 +29,17 @@ func PrettyString(in interface{}) string {
 	jsonStr, err := json.MarshalIndent(in, "", "    ")
 	if err != nil {
 		if common.DebugEnabled {
-			err := fmt.Errorf("unable to marshal, Error: %+v", err)
-			if err != nil {
-				fmt.Printf("unable to marshal, Error: %+v\n", err)
-			}
+			fmt.Printf("unable to marshal, Error: %+v\n", err)
 		}
 		return fmt.Sprintf("%+v", in)
 	}
+
 	return string(jsonStr)
 }
 
 // ReplaceHexCodesWithValue finds any string slice which is equivalent to hexadecimal value of
 // a character then it replaces that with its value.
-// If any error occured while resolving it leaves that part as it is.
+// If any error occurred while resolving it leaves that part as it is.
 // e.g. "\\x20" in a string will be replaced with value of "\x20" i.e. space
 func ReplaceHexCodesWithValue(s string) (string, error) {
 	regexString := "\\\\[xX][0-9a-fA-F]{2}"
@@ -50,7 +48,7 @@ func ReplaceHexCodesWithValue(s string) (string, error) {
 	return pattern.ReplaceAllStringFunc(s, func(s string) string {
 		bytes, err := hex.DecodeString(s[2:])
 		if err != nil {
-			glog.Errorf("Error occured while resolving %q. Error: %+v", s, err)
+			glog.Errorf("Error occurred while resolving %q. Error: %+v", s, err)
 			return s
 		}
 		return string(bytes)

--- a/utils/system/exec.go
+++ b/utils/system/exec.go
@@ -27,7 +27,7 @@ import (
 // ExecCommand executes the command supplied and return the output as well as error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommand(cmd string) (string, error) {
 	if common.DebugEnabled {
@@ -47,7 +47,7 @@ func ExecCommand(cmd string) (string, error) {
 // It also takes one sync.WaitGroup object as an argument which it notifies once command is executed
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandSync(cmd string, wg *sync.WaitGroup) (string, error) {
 	out, err := ExecCommand(cmd)
@@ -58,7 +58,7 @@ func ExecCommandSync(cmd string, wg *sync.WaitGroup) (string, error) {
 // ExecCommandWithSudo executes the command supplied with `sudo` and return the output as well as error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandWithSudo(cmd string) (string, error) {
 	return ExecCommand("sudo " + cmd)
@@ -68,7 +68,7 @@ func ExecCommandWithSudo(cmd string) (string, error) {
 // It also takes one sync.WaitGroup object as an argument which it notifies once command is executed
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandWithSudoSync(cmd string, wg *sync.WaitGroup) (string, error) {
 	out, err := ExecCommandWithSudo(cmd)
@@ -89,7 +89,7 @@ func execCommandArrayWithGivenStdin(head string, parts []string, stdin string) (
 
 // ExecCommandArrayWithGivenStdin executes the command supplied
 // then feed the supplied stdin to commands stdin then return the output as well as error
-// don't use quotes in command or argument because that quote will be considerd
+// don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandArrayWithGivenStdin(cmd []string, stdin string) (string, error) {
 	return execCommandArrayWithGivenStdin(cmd[0], cmd[1:], stdin)
@@ -99,7 +99,7 @@ func ExecCommandArrayWithGivenStdin(cmd []string, stdin string) (string, error) 
 // then feed the supplied stdin to commands stdin then return the output as well as error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandWithGivenStdin(cmd, stdin string) (string, error) {
 	return ExecCommandArrayWithGivenStdin(strings.Fields(cmd), stdin)
@@ -107,7 +107,7 @@ func ExecCommandWithGivenStdin(cmd, stdin string) (string, error) {
 
 // ExecCommandArrayWithGivenStdinWithSudo executes the command supplied with `sudo`
 // then feed the supplied stdin to commands stdin then return the output as well as error
-// don't use quotes in command or argument because that quote will be considerd
+// don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandArrayWithGivenStdinWithSudo(cmd []string, stdin string) (string, error) {
 	return execCommandArrayWithGivenStdin("sudo", cmd, stdin)
@@ -117,7 +117,7 @@ func ExecCommandArrayWithGivenStdinWithSudo(cmd []string, stdin string) (string,
 // then feed the supplied stdin to commands stdin then return the output as well as error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecCommandWithGivenStdinWithSudo(cmd, stdin string) (string, error) {
 	return ExecCommandArrayWithGivenStdinWithSudo(strings.Fields(cmd), stdin)
@@ -173,7 +173,7 @@ func ExecPipeTwoCommandsArray(cmd1, cmd2 []string) (string, error) {
 // and feed its output to second command as input
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func ExecPipeTwoCommands(cmd1, cmd2 string) (string, error) {
 	// splitting head => g++ parts => rest of the command

--- a/utils/system/run.go
+++ b/utils/system/run.go
@@ -26,7 +26,7 @@ import (
 // RunCommand executes the command supplied and return the error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommand(cmd string) error {
 	if common.DebugEnabled {
@@ -45,7 +45,7 @@ func RunCommand(cmd string) error {
 // RunCommandWithSudo executes the command supplied and return the error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommandWithSudo(cmd string) error {
 	return RunCommand("sudo " + cmd)
@@ -72,7 +72,7 @@ func runCommandArrayWithGivenStdin(head string, parts []string, stdin string) er
 
 // RunCommandArrayWithGivenStdin runs the command supplied
 // then feed the supplied stdin to commands stdin then return the error
-// don't use quotes in command or argument because that quote will be considerd
+// don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommandArrayWithGivenStdin(cmd []string, stdin string) error {
 	return runCommandArrayWithGivenStdin(cmd[0], cmd[1:], stdin)
@@ -82,7 +82,7 @@ func RunCommandArrayWithGivenStdin(cmd []string, stdin string) error {
 // then feed the supplied stdin to commands stdin then return error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommandWithGivenStdin(cmd, stdin string) error {
 	return RunCommandArrayWithGivenStdin(strings.Fields(cmd), stdin)
@@ -90,7 +90,7 @@ func RunCommandWithGivenStdin(cmd, stdin string) error {
 
 // RunCommandArrayWithGivenStdinWithSudo runs the command supplied with `sudo`
 // then feed the supplied stdin to commands stdin then return the error
-// don't use quotes in command or argument because that quote will be considerd
+// don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommandArrayWithGivenStdinWithSudo(cmd []string, stdin string) error {
 	return runCommandArrayWithGivenStdin("sudo", cmd, stdin)
@@ -100,7 +100,7 @@ func RunCommandArrayWithGivenStdinWithSudo(cmd []string, stdin string) error {
 // then feed the supplied stdin to commands stdin then return the error
 // Since this function splits the commands on whitespaces, avoid those commands
 // whose argument has space or if the command itself have the space
-// Also don't use quotes in command or argument because that quote will be considerd
+// Also don't use quotes in command or argument because that quote will be considered
 // part of the command
 func RunCommandWithGivenStdinWithSudo(cmd, stdin string) error {
 	return RunCommandArrayWithGivenStdinWithSudo(strings.Fields(cmd), stdin)


### PR DESCRIPTION
corrects mis-spells, linting issues and some other issues as well.

Changes committed:
	modified:   common/common.go
	modified:   config/config.go
	modified:   environments/docker/general.go
	modified:   environments/docker/teardown.go
	modified:   environments/minikube/general.go
	modified:   environments/minikube/setup.go
	modified:   utils/k8s/k8s.go
	modified:   utils/string/string.go
	modified:   utils/system/exec.go
	modified:   utils/system/run.go

Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>