### PR TITLE
The neat way to create CITF instance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,18 @@ install:
       mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/openebs;
       cd $GOPATH/src/github.com/openebs/CITF;
     fi
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl
+  - sudo chmod +x ./kubectl
+  - sudo mv ./kubectl /usr/local/bin/
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64
+  - sudo chmod +x minikube
+  - sudo mv minikube /usr/local/bin/
 
 script:
   - make
   - make gocyclo
   - make test
+  - make integration-test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ build: vet fmt golint
 # Tools required for different make targets or for development purposes
 EXTERNAL_TOOLS = \
 	github.com/fzipp/gocyclo \
-	golang.org/x/lint/golint
+	golang.org/x/lint/golint \
+	github.com/onsi/ginkgo/ginkgo \
+	github.com/onsi/gomega/...
 
 vet:
 	go list ./... | grep -v "./vendor/*" | xargs go vet
@@ -25,6 +27,9 @@ gocyclo:
 test: vet fmt
 	@echo "--> Running go test";
 	$(PWD)/test.sh
+
+integration-test:
+	go test -v github.com/openebs/CITF/example
 
 # Bootstrap the build by downloading additional tools
 bootstrap:

--- a/citf_options/citf_options.go
+++ b/citf_options/citf_options.go
@@ -1,0 +1,53 @@
+package citfoptions
+
+// CreateOptions specifies which fields of CITF should be included when created or reloadedd
+type CreateOptions struct {
+	ConfigPath         string
+	EnvironmentInclude bool
+	K8SInclude         bool
+	DockerInclude      bool
+	LoggerInclude      bool
+}
+
+// CreateOptionsIncludeAll returns CreateOptions where all fields are set to `true` and ConfigPath is set to configPath
+func CreateOptionsIncludeAll(configPath string) *CreateOptions {
+	var citfCreateOptions CreateOptions
+	citfCreateOptions.ConfigPath = configPath
+	citfCreateOptions.EnvironmentInclude = true
+	citfCreateOptions.K8SInclude = true
+	citfCreateOptions.DockerInclude = true
+	citfCreateOptions.LoggerInclude = true
+	return &citfCreateOptions
+}
+
+// CreateOptionsIncludeAllButEnvironment returns CreateOptions where all fields except `Environment` are set to `true` and ConfigPath is set to configPath
+func CreateOptionsIncludeAllButEnvironment(configPath string) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+
+	citfCreateOptions.EnvironmentInclude = false
+	return citfCreateOptions
+}
+
+// CreateOptionsIncludeAllButK8s returns CreateOptions where all fields except `K8S` are set to `true` and ConfigPath is set to configPath
+func CreateOptionsIncludeAllButK8s(configPath string) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+
+	citfCreateOptions.K8SInclude = false
+	return citfCreateOptions
+}
+
+// CreateOptionsIncludeAllButDocker returns CreateOptions where all fields except `Docker` are set to `true` and ConfigPath is set to configPath
+func CreateOptionsIncludeAllButDocker(configPath string) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+
+	citfCreateOptions.DockerInclude = false
+	return citfCreateOptions
+}
+
+// CreateOptionsIncludeAllButLogger returns CreateOptions where all fields except `Logger` are set to `true` and ConfigPath is set to configPath
+func CreateOptionsIncludeAllButLogger(configPath string) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+
+	citfCreateOptions.LoggerInclude = false
+	return citfCreateOptions
+}

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -1,0 +1,73 @@
+package example
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openebs/CITF"
+	citfoptions "github.com/openebs/CITF/citf_options"
+)
+
+var CitfInstance citf.CITF
+
+func TestIntegrationExample(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var err error
+	// Initializing CITF without config file.
+	// Also We should not include K8S as currently we don't have kubernetes environment setup
+	CitfInstance, err = citf.NewCITF(citfoptions.CreateOptionsIncludeAllButK8s(""))
+	Expect(err).NotTo(HaveOccurred())
+
+	RunSpecs(t, "Integration Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+
+	// Setting up the default Platform i.e minikube
+	err := CitfInstance.Environment.Setup()
+	Expect(err).NotTo(HaveOccurred())
+
+	// You have to update the K8s config when environment has been set up
+	// this extra step will be unsolicited in upcoming changes.
+	err = CitfInstance.Reload(citfoptions.CreateOptionsIncludeAll(""))
+	Expect(err).NotTo(HaveOccurred())
+
+	// Wait until platform is up
+	time.Sleep(30 * time.Second)
+
+	err = CitfInstance.K8S.YAMLApply("./nginx-rc.yaml")
+	Expect(err).NotTo(HaveOccurred())
+
+	// Wait until the pod is up and running
+	time.Sleep(30 * time.Second)
+})
+
+var _ = AfterSuite(func() {
+
+	// Tear Down the Platform
+	err := CitfInstance.Environment.Teardown()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("Integration Test", func() {
+	When("We check the log", func() {
+		It("has `started the controller` in the log", func() {
+			pods, err := CitfInstance.K8S.GetPods("default", "nginx")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Give pods some time to generate logs
+			time.Sleep(2 * time.Second)
+
+			// Assuming that only 1 nginx pod is running
+			for _, v := range pods {
+				log, err := CitfInstance.K8S.GetLog(v.GetName(), "default")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(log).Should(ContainSubstring("started the controller"))
+			}
+		})
+	})
+})

--- a/example/nginx-rc.yaml
+++ b/example/nginx-rc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        args: [/bin/sh, -c,
+            'echo "started the controller"']
+        ports:
+        - containerPort: 80

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@
 
 set -e
 echo "" > coverage.txt
-PACKAGES=$(go list ./... | grep -v '/vendor/')
+PACKAGES=$(go list ./... | grep -Ev 'example|/vendor/')
 for d in $PACKAGES; do
 	go test -coverprofile=profile.out -covermode=atomic $d
 	if [ -f profile.out ]; then

--- a/utils/k8s/general.go
+++ b/utils/k8s/general.go
@@ -16,7 +16,6 @@ package k8s
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"github.com/openebs/CITF/config"
 	"github.com/openebs/CITF/utils/log"
 	api_core_v1 "k8s.io/api/core/v1"
@@ -37,20 +36,14 @@ type K8S struct {
 
 // NewK8S returns K8S struct
 func NewK8S() (K8S, error) {
-	var config *rest.Config
-	var clientset *kubernetes.Clientset
-	var err error
+	config, err := GetClientConfig()
+	if err != nil {
+		return K8S{}, err
+	}
 
-	// For now we are ignoring this error, as we know with current design
-	// we may end-up trying to create Config even if there is no config present in the machine yet
-	config, err = GetClientConfig()
-	if err == nil {
-		clientset, err = GetClientsetFromConfig(config)
-		if err != nil {
-			return K8S{}, err
-		}
-	} else {
-		glog.Error(err)
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return K8S{}, err
 	}
 
 	return K8S{


### PR DESCRIPTION
- Introduced package `citfoptions` which Contains struct `CreateOptions`
and a few functions to speedup the creation.
- NewCITF will now take a `citfoptions.CreateOptions` which will specify
which parts of CITF should be created.
- Updated `ReadMe.md` with some information about changes and updated example with new changes.
- Put same example in a new directory `example` and excluded it from test.
- Run `example/example_test.go` as part of `integration-test` in travis

Changes committed:
	modified:   README.md
	modified:   citf.go
	new file:   citf_options/citf_options.go
	new file:   example/example_test.go
	new file:   example/nginx-rc.yaml
	modified:   test.sh
	modified:   utils/k8s/general.go

Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>