### PR TITLE
Add testing variable to CITF logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Developer has to instantiate CITF using `citf.NewCITF` function, which will init
 
 > If you want all options in `CreateOptions` to set to `true`  you may use `citfoptions.CreateOptionsIncludeAll` function.
 
+> **Note:** `citfoptions.CreateOptions.T` is compatible with golang's standard `*testing.T` as well as ginkgo's `ginkgo.GinkgoTInterface`. We can get `ginkgo.GinkgoTInterface` by `ginkgo.GinkgoT()`.
+
 CITF struct has four fields:- 
 - Environment - To Setup or TearDown the platform such as minikube, GKE, AWS etc.
 - K8S - K8S will have Kubernetes ClientSet & Config.
@@ -78,8 +80,7 @@ Environment: minikube
 
 If environment variable and config file are not present, then CITF will take default environment which is minikube.
 
-<details>
-<summary><b>Platform Operations</b></summary>
+### Platform Operations
 
 `citf.Environment` will handle operations related to the platforms. 
 
@@ -88,118 +89,5 @@ In order to setup the k8s cluster, developer needs to call the `Setup()` method 
 Developer can also check the status of the platform using `Status()` method.
 
 Once integration test is completed, developer can delete the setup using `TearDown()` method.
-</details>
 
-
-<details>
-<summary><b>Example</b></summary>
-
-## example_test.go
-
-```go
-package example
-
-import (
-	"testing"
-	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/openebs/CITF"
-	citfoptions "github.com/openebs/CITF/citf_options"
-)
-
-var CitfInstance citf.CITF
-
-func TestIntegrationExample(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	var err error
-	// Initializing CITF without config file.
-	// Also We should not include K8S as currently we don't have kubernetes environment setup
-	CitfInstance, err = citf.NewCITF(citfoptions.CreateOptionsIncludeAllButK8s(""))
-	Expect(err).NotTo(HaveOccurred())
-
-	RunSpecs(t, "Integration Test Suite")
-}
-
-var _ = BeforeSuite(func() {
-
-	// Setting up the default Platform i.e minikube
-	err := CitfInstance.Environment.Setup()
-	Expect(err).NotTo(HaveOccurred())
-
-	// You have to update the K8s config when environment has been set up
-	// this extra step will be unsolicited in upcoming changes.
-	err = CitfInstance.Reload(citfoptions.CreateOptionsIncludeAll(""))
-	Expect(err).NotTo(HaveOccurred())
-
-	// Wait until platform is up
-	time.Sleep(30 * time.Second)
-
-	err = CitfInstance.K8S.YAMLApply("./nginx-rc.yaml")
-	Expect(err).NotTo(HaveOccurred())
-
-	// Wait until the pod is up and running
-	time.Sleep(30 * time.Second)
-})
-
-var _ = AfterSuite(func() {
-
-	// Tear Down the Platform
-	err := CitfInstance.Environment.Teardown()
-	Expect(err).NotTo(HaveOccurred())
-})
-
-var _ = Describe("Integration Test", func() {
-	When("We check the log", func() {
-		It("has `started the controller` in the log", func() {
-			pods, err := CitfInstance.K8S.GetPods("default", "nginx")
-			Expect(err).NotTo(HaveOccurred())
-
-			// Give pods some time to generate logs
-			time.Sleep(2 * time.Second)
-
-			// Assuming that only 1 nginx pod is running
-			for _, v := range pods {
-				log, err := CitfInstance.K8S.GetLog(v.GetName(), "default")
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(log).Should(ContainSubstring("started the controller"))
-			}
-		})
-	})
-})
-```
-
-Above example is using [Ginkgo](https://github.com/onsi/ginkgo) and [Gomega](https://github.com/onsi/gomega) framework for handling the tests.
-
-`nginx-rc.yaml` which is used in above example is below.
-
-## nginx-rc.yaml
-```yaml
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: nginx
-spec:
-  replicas: 1
-  selector:
-    app: nginx
-  template:
-    metadata:
-      name: nginx
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx
-        args: [/bin/sh, -c,
-            'echo "started the controller"']
-        ports:
-        - containerPort: 80
-```
-> **Note:** Above yaml is compatible with kubernetes 1.9, you may need to modify it if your kubernetes version is different.
-
-</details>
+> Examples for this can be found [here](https://github.com/openebs/CITF/tree/master/example).

--- a/citf.go
+++ b/citf.go
@@ -75,7 +75,9 @@ func (citfInstance *CITF) Reload(citfCreateOptions *citfoptions.CreateOptions) e
 	}
 
 	if citfCreateOptions.LoggerInclude {
-		citfInstance.Logger = log.Logger{}
+		citfInstance.Logger = log.Logger{
+			T: citfCreateOptions.T,
+		}
 	}
 
 	citfInstance.DebugEnabled = config.Debug()

--- a/citf_options/citf_options.go
+++ b/citf_options/citf_options.go
@@ -1,52 +1,56 @@
 package citfoptions
 
-// CreateOptions specifies which fields of CITF should be included when created or reloadedd
+import "github.com/openebs/CITF/utils/log"
+
+// CreateOptions specifies which fields of CITF should be included when created or reloaded
 type CreateOptions struct {
 	ConfigPath         string
 	EnvironmentInclude bool
 	K8SInclude         bool
 	DockerInclude      bool
 	LoggerInclude      bool
+	T                  log.LoggerT
 }
 
 // CreateOptionsIncludeAll returns CreateOptions where all fields are set to `true` and ConfigPath is set to configPath
-func CreateOptionsIncludeAll(configPath string) *CreateOptions {
+func CreateOptionsIncludeAll(configPath string, t log.LoggerT) *CreateOptions {
 	var citfCreateOptions CreateOptions
 	citfCreateOptions.ConfigPath = configPath
 	citfCreateOptions.EnvironmentInclude = true
 	citfCreateOptions.K8SInclude = true
 	citfCreateOptions.DockerInclude = true
 	citfCreateOptions.LoggerInclude = true
+	citfCreateOptions.T = t
 	return &citfCreateOptions
 }
 
 // CreateOptionsIncludeAllButEnvironment returns CreateOptions where all fields except `Environment` are set to `true` and ConfigPath is set to configPath
-func CreateOptionsIncludeAllButEnvironment(configPath string) *CreateOptions {
-	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+func CreateOptionsIncludeAllButEnvironment(configPath string, t log.LoggerT) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath, t)
 
 	citfCreateOptions.EnvironmentInclude = false
 	return citfCreateOptions
 }
 
 // CreateOptionsIncludeAllButK8s returns CreateOptions where all fields except `K8S` are set to `true` and ConfigPath is set to configPath
-func CreateOptionsIncludeAllButK8s(configPath string) *CreateOptions {
-	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+func CreateOptionsIncludeAllButK8s(configPath string, t log.LoggerT) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath, t)
 
 	citfCreateOptions.K8SInclude = false
 	return citfCreateOptions
 }
 
 // CreateOptionsIncludeAllButDocker returns CreateOptions where all fields except `Docker` are set to `true` and ConfigPath is set to configPath
-func CreateOptionsIncludeAllButDocker(configPath string) *CreateOptions {
-	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+func CreateOptionsIncludeAllButDocker(configPath string, t log.LoggerT) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath, t)
 
 	citfCreateOptions.DockerInclude = false
 	return citfCreateOptions
 }
 
 // CreateOptionsIncludeAllButLogger returns CreateOptions where all fields except `Logger` are set to `true` and ConfigPath is set to configPath
-func CreateOptionsIncludeAllButLogger(configPath string) *CreateOptions {
-	citfCreateOptions := CreateOptionsIncludeAll(configPath)
+func CreateOptionsIncludeAllButLogger(configPath string, t log.LoggerT) *CreateOptions {
+	citfCreateOptions := CreateOptionsIncludeAll(configPath, t)
 
 	citfCreateOptions.LoggerInclude = false
 	return citfCreateOptions

--- a/environments/minikube/general.go
+++ b/environments/minikube/general.go
@@ -36,7 +36,7 @@ func init() {
 	// Check if `minikube` is present
 	minikubePath, err := sysutil.BinPathFromPathEnv(common.Minikube)
 	if minikubePath == "" {
-		logger.LogFatalf(err, "%q not found in current directory or in directories represented by PATH environment variable", common.Minikube)
+		logger.LogTestErrorf(err, "%q not found in current directory or in directories represented by PATH environment variable", common.Minikube)
 	}
 	glog.Infof("%q found on path: %q", common.Minikube, minikubePath)
 

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -18,7 +18,7 @@ func TestIntegrationExample(t *testing.T) {
 	var err error
 	// Initializing CITF without config file.
 	// Also We should not include K8S as currently we don't have kubernetes environment setup
-	CitfInstance, err = citf.NewCITF(citfoptions.CreateOptionsIncludeAllButK8s(""))
+	CitfInstance, err = citf.NewCITF(citfoptions.CreateOptionsIncludeAllButK8s("", GinkgoT()))
 	Expect(err).NotTo(HaveOccurred())
 
 	RunSpecs(t, "Integration Test Suite")
@@ -32,7 +32,7 @@ var _ = BeforeSuite(func() {
 
 	// You have to update the K8s config when environment has been set up
 	// this extra step will be unsolicited in upcoming changes.
-	err = CitfInstance.Reload(citfoptions.CreateOptionsIncludeAll(""))
+	err = CitfInstance.Reload(citfoptions.CreateOptionsIncludeAll("", GinkgoT()))
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait until platform is up

--- a/utils/k8s/k8s.go
+++ b/utils/k8s/k8s.go
@@ -98,7 +98,7 @@ func (k8s K8S) GetPods(namespace, podNamePrefix string) ([]core_v1.Pod, error) {
 }
 
 // GetPodsUntilQuitSignal returns all the Pods object which has a prefix specified in its name in the given namespace.
-// it tries to get the pods which match the criteria unless `true` recieved from `quit` or it gets at least one such pod.
+// it tries to get the pods which match the criteria unless `true` received from `quit` or it gets at least one such pod.
 // NOTE: it counts pods which are not even in ContainerCreating state yet. Deal with them properly.
 func (k8s K8S) GetPodsUntilQuitSignal(namespace, podNamePrefix string, quit <-chan bool) (thePods []core_v1.Pod, err error) {
 	for {
@@ -108,12 +108,12 @@ func (k8s K8S) GetPodsUntilQuitSignal(namespace, podNamePrefix string, quit <-ch
 				if len(thePods) == 0 {
 					err = fmt.Errorf("failed to get any pod which starts with %q, forced to quit", podNamePrefix)
 				} else {
-					glog.Info("quit signal recieved `true`, quitting...")
+					glog.Info("quit signal received `true`, quitting...")
 					err = nil
 				}
 				return
 			}
-			glog.Info("quit signal recieved `false`, not quitting...")
+			glog.Info("quit signal received `false`, not quitting...")
 
 		default:
 			thePods, err = k8s.GetPods(namespace, podNamePrefix)
@@ -260,7 +260,7 @@ func (k8s K8S) GetContainerStateByIndexInPod(pod *core_v1.Pod, containerIndex in
 		err = fmt.Errorf("pod %q of namespace %q has only %d container(s) but expecting %d containers", pod.Name, pod.Namespace, len(containerStates), containerIndex+1)
 		// inside this block expected number of containers (i. e. containerIndex+1) are always more than one
 		// because control will enter this block only when number of containers is 1 or more than one
-		// but when at least 1 container is present in the pod containerIndex can't be more or equal unless it is atleast 1
+		// but when at least 1 container is present in the pod containerIndex can't be more or equal unless it is at least 1
 		// and when containerIndex is at least one then we are expecting at least 2 containers in the pod (number of containers = containerIndex+1)
 		// thats why in above message I have written containers instead of container(s) for expected number.
 	} else { // if there is enough containers

--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -11,8 +12,31 @@ import (
 // DebugEnabled specifies if this package print debug information
 var DebugEnabled = false
 
+// LoggerT is the interface required to log test specific errors
+// golang's standard `*testing.T` and `ginkgo.GinkgoTInterface` both implements this interface
+type LoggerT interface {
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+}
+
 // Logger is a struct which will help to call CITF specific logging functions
-type Logger struct{}
+type Logger struct {
+	T LoggerT
+}
+
+// below four methods are responsible to maintain uniform appearance of error message in logs
+
+// ErrorMessageFromInterfaces prepares the message with one error and other interfaces
+func (logger Logger) ErrorMessageFromInterfaces(err error, a ...interface{}) string {
+	return fmt.Sprint(append(a, ":", err)...)
+}
+
+// ErrorMessageFromFormatString prepares the message over format string `message` and interfaces representing each format specifier
+func (logger Logger) ErrorMessageFromFormatString(err error, message string, a ...interface{}) string {
+	return fmt.Sprintf(strings.TrimSpace(message)+": "+err.Error(), a...)
+}
 
 // WritefDebugMessage formats according to a format specifier and writes to w only when DebugEnabled is true.
 // A newline is always appended. It returns the number of bytes written and any write error encountered.
@@ -21,12 +45,6 @@ func (logger Logger) WritefDebugMessage(w io.Writer, format string, a ...interfa
 		return fmt.Fprintf(w, format+"\n", a...)
 	}
 	return
-}
-
-// PrintfDebugMessage formats according to a format specifier and writes to standard output only when DebugEnabled is true.
-// //  A newline is always appended. It returns the number of bytes written and any write error encountered.
-func (logger Logger) PrintfDebugMessage(format string, a ...interface{}) (n int, err error) {
-	return logger.WritefDebugMessage(os.Stdout, format, a...)
 }
 
 // WritelnDebugMessage formats using the default formats for its operands and writes to w only when DebugEnabled.
@@ -39,6 +57,12 @@ func (logger Logger) WritelnDebugMessage(w io.Writer, a ...interface{}) (n int, 
 	return
 }
 
+// PrintfDebugMessage formats according to a format specifier and writes to standard output only when DebugEnabled is true.
+// //  A newline is always appended. It returns the number of bytes written and any write error encountered.
+func (logger Logger) PrintfDebugMessage(format string, a ...interface{}) (n int, err error) {
+	return logger.WritefDebugMessage(os.Stdout, format, a...)
+}
+
 // PrintlnDebugMessage formats using the default formats for its operands and writes to standard output only when DebugEnabled.
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
@@ -46,26 +70,66 @@ func (logger Logger) PrintlnDebugMessage(a ...interface{}) (n int, err error) {
 	return logger.WritelnDebugMessage(os.Stdout, a...)
 }
 
+// Log logs the info on testing variable (using `logger.T.Log`) if `logger.T` is not nil
+// otherwise it uses `logger.PrintfDebugMessage`
+func (logger Logger) Log(a ...interface{}) (n int, err error) {
+	if logger.T != nil {
+		logger.T.Log(a...)
+	} else {
+		return logger.PrintlnDebugMessage(a...)
+	}
+	return
+}
+
+// Logf logs the info on testing variable (using `logger.T.Logf`) if `logger.T` is not nil
+// otherwise it uses `logger.PrintfDebugMessage`
+func (logger Logger) Logf(format string, a ...interface{}) (n int, err error) {
+	if logger.T != nil {
+		logger.T.Logf(format, a...)
+	} else {
+		return logger.PrintfDebugMessage(format, a...)
+	}
+	return
+}
+
+// LogfDebugMessage logs the info if DebugEnabled. it does so on testing variable (using `logger.T.Logf`) if `logger.T` is not nil
+// otherwise it uses `logger.PrintfDebugMessage`
+func (logger Logger) LogfDebugMessage(format string, a ...interface{}) (n int, err error) {
+	if DebugEnabled {
+		return logger.Logf(format, a...)
+	}
+	return
+}
+
+// LogDebugMessage logs the info if DebugEnabled. it does so on testing variable (using `logger.T.Logf`) if `logger.T` is not nil
+// otherwise it uses `logger.PrintfDebugMessage`
+func (logger Logger) LogDebugMessage(a ...interface{}) (n int, err error) {
+	if DebugEnabled {
+		return logger.Log(a...)
+	}
+	return
+}
+
 // LogError logs error using `glog.Error` only when err is not nil.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
 func (logger Logger) LogError(err error, message string) {
 	if err != nil {
-		glog.Error(message+":", err)
+		glog.Error(logger.ErrorMessageFromInterfaces(err, message))
 	}
 }
 
 // LogNonError logs info using `glog.Info` only when err is nil.
-func (logger Logger) LogNonError(err error, message string) {
+func (logger Logger) LogNonError(err error, a ...interface{}) {
 	if err == nil {
-		glog.Info(message)
+		glog.Info(a...)
 	}
 }
 
 // LogErrorf formats according to a format specifier and logs error using `glog.Error` only when err is not nil.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
 func (logger Logger) LogErrorf(err error, message string, a ...interface{}) {
 	if err != nil {
-		glog.Error(fmt.Sprintf(message, a...)+":", err)
+		glog.Error(logger.ErrorMessageFromFormatString(err, message, a...))
 	}
 }
 
@@ -77,26 +141,79 @@ func (logger Logger) LogNonErrorf(err error, message string, a ...interface{}) {
 	}
 }
 
+// logFatal is a plain function which does straight forward task of preparing and logging the error and exit.
+// it is meant to be used in other functions of this package which requires above two requirements.
+func (logger Logger) logFatal(err error, a ...interface{}) {
+	glog.Fatal(logger.ErrorMessageFromInterfaces(err, a...))
+}
+
+// logFatalf is a plain function which does straight forward task of preparing and logging the error and exit.
+// it is meant to be used in other functions of this package which requires above two requirements.
+func (logger Logger) logFatalf(err error, message string, a ...interface{}) {
+	glog.Fatal(logger.ErrorMessageFromFormatString(err, message, a...))
+}
+
 // LogFatal logs error using `glog.Error` only when err is not nil.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
-func (logger Logger) LogFatal(err error, message string) {
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
+func (logger Logger) LogFatal(err error, a ...interface{}) {
 	if err != nil {
-		glog.Fatal(message+":", err)
+		logger.logFatal(err, a...)
 	}
 }
 
 // LogFatalf formats according to a format specifier and logs error using `glog.Error` only when err is not nil.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
 func (logger Logger) LogFatalf(err error, message string, a ...interface{}) {
 	if err != nil {
-		glog.Fatal(fmt.Sprintf(message, a...)+":", err)
+		logger.logFatalf(err, message, a...)
 	}
 }
 
-// PrintError wtires error message to os.StdErr only when err is not nil.
+// LogTestError logs test error only when err is not nil.
+// It does so using `logger.T.Error` if `logger.T` is not nil, otherwise it uses `glog.Fatal` (BE AWARE)
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
+func (logger Logger) LogTestError(err error, a ...interface{}) {
+	if err != nil {
+		if logger.T != nil {
+			logger.T.Error(a...)
+		} else {
+			logger.logFatal(err, a...)
+		}
+	}
+}
+
+// LogTestNonError logs info using `logger.Log` but only when err is nil.
+func (logger Logger) LogTestNonError(err error, a ...interface{}) {
+	if err == nil {
+		logger.Log(a...)
+	}
+}
+
+// LogTestErrorf formats according to a format specifier and logs error only when err is not nil.
+// It does so using `logger.T.Errorf` if `logger.T` is not nil, otherwise it uses `glog.Fatal` (BE AWARE)
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
+func (logger Logger) LogTestErrorf(err error, message string, a ...interface{}) {
+	if err != nil {
+		if logger.T != nil {
+			logger.T.Errorf(message, a...)
+		} else {
+			logger.logFatalf(err, message, a...)
+		}
+	}
+}
+
+// LogTestNonErrorf logs info using `Logf` only when err is nil.
+// formatting is taken care by `glog.Infof` pr `logger.T.Logf` accordingly.
+func (logger Logger) LogTestNonErrorf(err error, message string, a ...interface{}) {
+	if err == nil {
+		logger.Logf(message, a...)
+	}
+}
+
+// PrintError writes error message to os.StdErr only when err is not nil.
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
 func (logger Logger) PrintError(err error, message string) (n int, errr error) {
 	if err != nil {
 		return fmt.Fprintln(os.Stderr, message+":", err)
@@ -104,7 +221,7 @@ func (logger Logger) PrintError(err error, message string) (n int, errr error) {
 	return
 }
 
-// PrintNonError wtites info message to os.Stdout only when err is nil.
+// PrintNonError writes info message to os.Stdout only when err is nil.
 // Spaces are always added between operands and a newline is appended.
 // It returns the number of bytes written and any write error encountered.
 func (logger Logger) PrintNonError(err error, message string) (n int, errr error) {
@@ -114,9 +231,9 @@ func (logger Logger) PrintNonError(err error, message string) (n int, errr error
 	return
 }
 
-// PrintErrorf formats according to a format specifier and wtires error message to os.StdErr only when err is not nil.
+// PrintErrorf formats according to a format specifier and writes error message to os.StdErr only when err is not nil.
 // A newline is always appended. It returns the number of bytes written and any write error encountered.
-// Please follow convensions for error message e.g. start with lowercase, don't end with period etc.
+// Please follow conventions for error message e.g. start with lowercase, don't end with period etc.
 func (logger Logger) PrintErrorf(err error, message string, a ...interface{}) (n int, errr error) {
 	if err != nil {
 		a = append(a, err)
@@ -125,7 +242,7 @@ func (logger Logger) PrintErrorf(err error, message string, a ...interface{}) (n
 	return
 }
 
-// PrintNonErrorf formats according to a format specifier and wtites info message to os.Stdout only when err is nil.
+// PrintNonErrorf formats according to a format specifier and writes info message to os.Stdout only when err is nil.
 // A newline is always appended. It returns the number of bytes written and any write error encountered.
 func (logger Logger) PrintNonErrorf(err error, message string, a ...interface{}) (n int, errr error) {
 	if err == nil {


### PR DESCRIPTION
After this PR, CITF will be able to log error on same testing variable which it's host program is using. As an example we don't need to use `glog.Fatal` which exits without notifying the control, instead we can use `Error` method on that variable which notify the control that this test has failed.

this PR contains following functionality
- a new interface which is compatible with golang's standard `*testing.T`
as well as ginkgo's `ginkgo.GinkgoTInterface`
- logger contains this variable so that it can easily log on that test
itself
- modified example to use this feature
- removed example from `README.md` to avoid redundancy
- codes following this
- refactored `logger` package a little to again avoid redundancy
- corrected some spelling mistakes

Changes committed:
	modified:   README.md
	modified:   citf.go
	modified:   citf_options/citf_options.go
	modified:   environments/minikube/general.go
	modified:   example/example_test.go
	modified:   utils/k8s/k8s.go
	modified:   utils/log/logger.go

Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>