### PR TITLE
utils.k8s.openebscrd: Add the support for Create in Storage Pool

### DIFF
--- a/utils/k8s/openebscrd.go
+++ b/utils/k8s/openebscrd.go
@@ -56,6 +56,12 @@ func (k8s K8S) DeleteCStorPool(cStorPoolName string, opts *meta_v1.DeleteOptions
 	return cStorePoolClient.Delete(cStorPoolName, opts)
 }
 
+// CreateStoragePool takes the representation of a StoragePool and creates it.
+func (k8s K8S) CreateStoragePool(storagePool *openebs_v1.StoragePool) (*openebs_v1.StoragePool, error) {
+	storagePoolClient := k8s.OpenebsClientSet.OpenebsV1alpha1().StoragePools()
+	return storagePoolClient.Create(storagePool)
+}
+
 // GetStoragePool returns the StoragePool object for the give storagePoolName
 func (k8s K8S) GetStoragePool(storagePoolName string, opts meta_v1.GetOptions) (*openebs_v1.StoragePool, error) {
 	storagePoolClient := k8s.OpenebsClientSet.OpenebsV1alpha1().StoragePools()


### PR DESCRIPTION
Fixes #63

This commit adds support for creating StoragePool objects. 

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>